### PR TITLE
Update app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,10 +46,9 @@ def index():
         Bucket=S3_BUCKET,
         Key=filename,
         Body=thumbnail,
-        ACL='public-read',
         ContentType='image/{}'.format(format),
     )
-
+    S3.put_object_acl(ACL='public-read', Bucket=S3_BUCKET, Key=filename)
     return {
         'url': 'https://s3.amazonaws.com/{}/{}'.format(S3_BUCKET, filename)
     }


### PR DESCRIPTION
Change modify of ACL to separate call so that chalice picks up on the action and adds `s3:PutObjectAcl` to the IAM Policy

I'm not sure if this is something that's changed with the GA of chalice but I was having trouble running your example as I was getting a permissions error, moving the update ACL call out to a separate function call caused chalice to detect it and add the appropriate policy eg:
```
Sams-iMac:callinone smachin$ chalice deploy
Updating lambda function...
Regen deployment package...
Updating IAM policy.

The following actions will be added to the execution policy:

s3:PutObjectAcl

Would you like to continue?  [Y/n]: y
Sending changes to lambda.
API Gateway rest API already found.
Deploying to: api
```

I guess chalice should be able to detect that ACL param within the `put_object` call so I'll raise that as a bug against the project too as I guess doing it this way will slightly slow down the execution time